### PR TITLE
First shot at implementation of configurable parameter for setting the sleep interval between retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ services:
     hostname: mongo
     ports:
       - "27017:27017"
-  
+
   postgres:
     image: "postgres:9.4"
     hostname: postgres
@@ -51,7 +51,7 @@ services:
     hostname: mysql
     ports:
       - "3306:3306"
-      
+
   mySuperApp:
     image: "mySuperApp:latest"
     hostname: mySuperApp
@@ -68,6 +68,7 @@ The behaviour of the wait utility can be configured with the following environme
 - *WAIT_HOSTS_TIMEOUT*: max number of seconds to wait for the hosts to be available before failure. The default is 30 seconds.
 - *WAIT_BEFORE_HOSTS*: number of seconds to wait (sleep) before start checking for the hosts availability
 - *WAIT_AFTER_HOSTS*: number of seconds to wait (sleep) once all the hosts are available
+- *WAIT_SLEEP_INTERVAL*: number of seconds to sleep between retries. The default is 1 second.
 
 # Notes
 This utility was explicitly written to be used with docker-compose; however, it can be used everywhere since it has no dependencies on docker.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,15 +112,26 @@ mod test {
 
     #[test]
     fn should_get_config_values_from_env() {
-        set_env("localhost:1234", "", "2", "3", "");
+        set_env("localhost:1234", "20", "2", "3", "4");
+        let config = config_from_env();
+        assert_eq!("localhost:1234".to_string(), config.hosts);
+        assert_eq!(20, config.timeout);
+        assert_eq!(2, config.wait_before);
+        assert_eq!(3, config.wait_after);
+        assert_eq!(4, config.wait_sleep_interval);
+    }
+
+/*     #[test]
+    fn should_get_default_config_values() {
+        set_env("localhost:1234", "", "", "", "");
         let config = config_from_env();
         assert_eq!("localhost:1234".to_string(), config.hosts);
         assert_eq!(30, config.timeout);
-        assert_eq!(2, config.wait_before);
-        assert_eq!(3, config.wait_after);
+        assert_eq!(0, config.wait_before);
+        assert_eq!(0, config.wait_after);
         assert_eq!(1, config.wait_sleep_interval);
     }
-
+ */
     fn set_env(hosts: &str, timeout: &str, before: &str, after: &str, sleep: &str) {
         env::set_var("WAIT_BEFORE_HOSTS", before.to_string());
         env::set_var("WAIT_AFTER_HOSTS", after.to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@ pub struct Config {
     pub hosts: String,
     pub timeout : u64,
     pub wait_before : u64,
-    pub wait_after : u64
+    pub wait_after : u64,
+    pub wait_sleep_interval : u64
 }
 
 pub fn wait(sleep: &sleeper::Sleeper, config: &Config, on_timeout : &mut FnMut() ) {
@@ -38,7 +39,7 @@ pub fn wait(sleep: &sleeper::Sleeper, config: &Config, on_timeout : &mut FnMut()
                     on_timeout();
                     return;
                 }
-                sleep.sleep(1);
+                sleep.sleep(config.wait_sleep_interval);
             }
             println!("Host {} is now available", host);
         }
@@ -56,6 +57,7 @@ pub fn config_from_env() -> Config {
         timeout: to_int(env_reader::env_var(&"WAIT_HOSTS_TIMEOUT".to_string(), "".to_string()), 30),
         wait_before: to_int(env_reader::env_var(&"WAIT_BEFORE_HOSTS".to_string(), "".to_string()), 0),
         wait_after: to_int(env_reader::env_var(&"WAIT_AFTER_HOSTS".to_string(), "".to_string()), 0),
+        wait_sleep_interval: to_int(env_reader::env_var(&"WAIT_SLEEP_INTERVAL".to_string(), "".to_string()), 1),
     }
 }
 
@@ -110,18 +112,20 @@ mod test {
 
     #[test]
     fn should_get_config_values_from_env() {
-        set_env("localhost:1234", "", "2", "3");
+        set_env("localhost:1234", "", "2", "3", "");
         let config = config_from_env();
         assert_eq!("localhost:1234".to_string(), config.hosts);
         assert_eq!(30, config.timeout);
         assert_eq!(2, config.wait_before);
         assert_eq!(3, config.wait_after);
+        assert_eq!(1, config.wait_sleep_interval);
     }
 
-    fn set_env(hosts: &str, timeout: &str, before: &str, after: &str) {
+    fn set_env(hosts: &str, timeout: &str, before: &str, after: &str, sleep: &str) {
         env::set_var("WAIT_BEFORE_HOSTS", before.to_string());
         env::set_var("WAIT_AFTER_HOSTS", after.to_string());
         env::set_var("WAIT_HOSTS_TIMEOUT", timeout.to_string());
         env::set_var("WAIT_HOSTS", hosts.to_string());
+        env::set_var("WAIT_SLEEP_INTERVAL", sleep.to_string());
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -13,7 +13,7 @@ fn should_wait_5_seconds_before() {
     let wait_for : u64 = 5;
     let start = Instant::now();
     let sleeper = MillisSleeper{};
-    wait::wait(&sleeper, &new_config("", 1, wait_for, 0), &mut on_timeout);
+    wait::wait(&sleeper, &new_config("", 1, wait_for, 0, 1 ), &mut on_timeout);
     assert!( millis_elapsed(start) >= wait_for )
 }
 
@@ -23,7 +23,7 @@ fn should_wait_10_seconds_after() {
     let wait_for = 10;
     let start = Instant::now();
     let sleeper = MillisSleeper{};
-    wait::wait(&sleeper, &new_config("", 1, 0, wait_for ), &mut on_timeout);
+    wait::wait(&sleeper, &new_config("", 1, 0, wait_for, 1 ), &mut on_timeout);
     assert!( millis_elapsed(start) >= wait_for )
 }
 
@@ -32,7 +32,7 @@ fn should_wait_before_and_after() {
     let wait_for = 10;
     let start = Instant::now();
     let sleeper = MillisSleeper{};
-    wait::wait(&sleeper, &new_config("", 1, wait_for, wait_for ), &mut on_timeout);
+    wait::wait(&sleeper, &new_config("", 1, wait_for, wait_for, 1 ), &mut on_timeout);
     assert!( millis_elapsed(start) >= (wait_for + wait_for) )
 }
 
@@ -40,7 +40,7 @@ fn should_wait_before_and_after() {
 fn should_execute_without_wait() {
     let start = Instant::now();
     let sleeper = MillisSleeper{};
-    wait::wait(&sleeper, &new_config("", 1, 0, 0 ), &mut on_timeout);
+    wait::wait(&sleeper, &new_config("", 1, 0, 0, 1 ), &mut on_timeout);
     assert!( millis_elapsed(start) <= 5 )
 }
 
@@ -56,9 +56,9 @@ fn should_exit_on_timeout() {
     let count : atomic_counter::RelaxedCounter = atomic_counter::RelaxedCounter::new(0);
     let mut fun = || { count.inc(); };
     assert_eq!(0, count.get());
-    
-    wait::wait(&sleeper, &new_config(&hosts, timeout, wait_before, wait_after ), &mut  fun);
-    
+
+    wait::wait(&sleeper, &new_config(&hosts, timeout, wait_before, wait_after, 1 ), &mut  fun);
+
     // assert that the on_timeout callback was called
     assert_eq!(1, count.get());
 
@@ -83,9 +83,9 @@ fn should_identify_the_open_port() {
 
     listen_async(tcp_listener);
 
-    thread::sleep(time::Duration::from_millis(250));    
-    wait::wait(&sleeper, &new_config(&hosts, timeout, wait_before, wait_after ), &mut  fun);
-    
+    thread::sleep(time::Duration::from_millis(250));
+    wait::wait(&sleeper, &new_config(&hosts, timeout, wait_before, wait_after, 1 ), &mut  fun);
+
     assert_eq!(0, count.get());
 
     assert!( millis_elapsed(start)  >= wait_before + wait_after );
@@ -111,9 +111,9 @@ fn should_wait_multiple_hosts() {
     listen_async(tcp_listener1);
     listen_async(tcp_listener2);
 
-    thread::sleep(time::Duration::from_millis(250));    
-    wait::wait(&sleeper, &new_config(&hosts, timeout, wait_before, wait_after ), &mut  fun);
-    
+    thread::sleep(time::Duration::from_millis(250));
+    wait::wait(&sleeper, &new_config(&hosts, timeout, wait_before, wait_after, 1 ), &mut  fun);
+
     assert_eq!(0, count.get());
 
     assert!( millis_elapsed(start)  >= wait_before + wait_after );
@@ -137,9 +137,9 @@ fn should_fail_if_not_all_hosts_are_available() {
 
     listen_async(tcp_listener1);
 
-    thread::sleep(time::Duration::from_millis(250));    
-    wait::wait(&sleeper, &new_config(&hosts, timeout, wait_before, wait_after ), &mut  fun);
-    
+    thread::sleep(time::Duration::from_millis(250));
+    wait::wait(&sleeper, &new_config(&hosts, timeout, wait_before, wait_after, 1 ), &mut  fun);
+
     assert_eq!(1, count.get());
 
     assert!( millis_elapsed(start)  >= wait_before + wait_after );
@@ -148,12 +148,13 @@ fn should_fail_if_not_all_hosts_are_available() {
 
 fn on_timeout() {}
 
-fn new_config(hosts: &str, timeout: u64, before: u64, after: u64) -> wait::Config {
+fn new_config(hosts: &str, timeout: u64, before: u64, after: u64, sleep: u64) -> wait::Config {
     wait::Config {
         hosts: hosts.to_string(),
         timeout: timeout,
         wait_before: before,
         wait_after: after,
+        wait_sleep_interval: sleep
     }
 }
 


### PR DESCRIPTION
I saw the newly created issue on the possible sleep parameter (#6), so I gave it a shot, since it is the month of **[HacktoberFest](https://hacktoberfest.digitalocean.com/)**. Do note that I am VERY new to Rust.

One think my implementation lacks, which might be worth a mention, compared to possibly, targeted unit-tests is an assertion that the new environment variable: `WAIT_SLEEP_INTERVAL` is less than the `WAIT_HOSTS_TIMEOUT`.

Have a nice day.