### PR TITLE
Upgrade TravisCI yml syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rust:
   - beta
   - nightly
 
-matrix:
+jobs:
   allow_failures:
     - rust: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: rust
 
-sudo: true
+os: linux
+  dist: xenial
 
 rust:
   - stable
   - beta
   - nightly
 
-matrix:
+jobs:
   allow_failures:
     - rust: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: rust
 
 os: linux
   
-  dist: "xenial"
+dist: "xenial"
 
 rust:
   - stable
   - beta
   - nightly
 
-jobs:
+matrix:
   allow_failures:
     - rust: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: rust
 
 os: linux
-  dist: xenial
+  
+  dist: "xenial"
 
 rust:
   - stable


### PR DESCRIPTION
The keyword `sudo` has been deprecated and has no effect anymore
The keywords `os` and `dist` should be explicit so we can see exactly what os will be used
The keyword `matrix` was an alias for the `jobs` command and should be replaced. 