### PR TITLE
Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '08:00'
+  open-pull-requests-limit: 99


### PR DESCRIPTION
## Adds Dependabot configuration

Dependabot is a company acquired by Github that scans build dependencies and keep than up to date.

The service is free and the results appear in the dependencies section under the Insights tab on every project