### PR TITLE
build: add multi-platform docker images for easier download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   build:
     strategy:
@@ -46,3 +50,57 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: target/artifacts/*
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: wait
+          path: target/artifacts/*
+  docker:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: wait
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Dockerfile
+        run: |
+          cat <<EOF > Dockerfile
+          FROM alpine AS builder
+          ARG TARGETPLATFORM
+          COPY . /
+          RUN if [ "\$TARGETPLATFORM" = "linux/amd64" ]; then mv /wait_x86_64 /wait; fi;
+          RUN if [ "\$TARGETPLATFORM" = "linux/arm64" ]; then mv /wait_aarch64 /wait; fi;
+          RUN if [ "\$TARGETPLATFORM" = "linux/arm/v7" ]; then mv /wait_armv7 /wait; fi;
+          RUN chmod +x /wait
+          FROM scratch
+          COPY --from=builder /wait /wait
+          EOF
+      - name: Docker metadata
+        id: docker-metadata
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}${{ github.event_name == 'workflow_dispatch' && format(',value={0}', github.event.inputs.version) || '' }}
+            type=semver,pattern={{major}}.{{minor}}${{ github.event_name == 'workflow_dispatch' && format(',value={0}', github.event.inputs.version) || '' }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64, linux/arm64, linux/arm/v7
+          push: true
+          tags: ${{ steps.docker-metadata.outputs.tags }}
+          labels: ${{ steps.docker-metadata.outputs.labels }}
+ 


### PR DESCRIPTION
Hi,

I've been using docker-compose-wait in my projects for two years, and it has helped me quickly constrain the dependencies between containers, which is even more useful than `depends_on`. Thank you for your efforts in providing us with such a great tool.

Currently, I have some suggestions for this project based on my experience using it.

If I want to build a multi-platform image, I have to carefully download the binary of `wait` for my platform among `wait_aarch64`, `wait_armv7`, and `wait_x86_64`, and then I also need to run `chmod +x`. This could be simplified by using a `COPY --from...` to automatically adapt to the target platform. This way, when building an image on an aarch64 machine, the aarch64 variant of `wait` would be gotten, along with the file permissions information, and no additional `chmod +x` step would be required. Here's an example Dockerfile using this approach:
```diff
- ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.11.0/wait /wait
- RUN chmod +x /wait
+ COPY --from=ghcr.io/ufoscout/docker-compose-wait:2.11.0/wait /wait
```

---

In this PR, I have extended the pipeline for releasing the binaries on GitHub, and added a step to build multi-platform images that are based on `scratch` and only contain the `wait` binary (so lightweight). These images are pushed to https://ghcr.io, and you don't need to take the extra effort to sign up for a Docker Hub account, nor a repository of Docker Images. You can see an example Docker image at https://github.com/zhangt2333/docker-compose-wait/pkgs/container/docker-compose-wait.

Thank you for considering my suggestions.